### PR TITLE
Add initial Cloudflare lunch order system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# weekllymealorder
-It is a meal order app that users can place meal order weekly. it allows quantity based price per order.
+# Weekly Lunch Ordering System – Setup & Usage
+**Platform:** Cloudflare Workers with D1 (database) and static assets.
+
+## Setup and Deployment
+1. **Install Dependencies:** Ensure Node.js is installed. Run `npm install` to install all dependencies.
+2. **Cloudflare Configuration:** Update the `wrangler.toml`:
+   - Set `"account_id"` to your Cloudflare account ID.
+   - Create a D1 database named "lunch_orders" (via `wrangler d1 create lunch_orders`) and update the `database_id` in `wrangler.toml` with your database's ID.
+3. **Database Schema:** Apply the schema and seed data to your D1 database:
+```bash
+npx wrangler d1 execute lunch_orders --file=schema.sql
+```
+This will create all tables and insert initial data (meals, options, admin users, etc.).
+4. **Build Frontend:** Compile the Svelte application with Tailwind:
+```bash
+npm run build
+```
+This outputs static assets to the `dist` directory (which the Worker will serve).
+5. **Cloudflare Access:** Configure Cloudflare Access to protect the application. Only authenticated users can reach the site, and the Worker relies on the `cf-access-authenticated-user-email` header to identify users. Ensure your Access policy passes this header. To grant admin rights, use the seeded admin emails (`alice@example.com`, `bob@example.com`) or update the `admin_users` table with your own email/user.
+6. **Development:** During development, run:
+```bash
+npm run dev
+```
+This will watch and rebuild the frontend on changes and run `wrangler dev` to serve the Worker locally. The application will be available at the localhost test address (by default, http://127.0.0.1:8787).
+7. **Testing:** Log in via Cloudflare Access. Regular users will see the weekly menu at the root URL (`/`). Admin users can access the admin interface at `/admin.html` (the Worker also redirects `/admin` to this page).
+8. **Deployment:** When ready to deploy, run:
+```bash
+npx wrangler publish
+```
+This will upload the Worker script and static assets to Cloudflare. Once published, the app will be live on your workers.dev subdomain or your configured custom domain route.
+
+## Usage
+- **User View:** Authenticated users can view the weekly menu on the home page. They can select a quantity for each meal variant and choose options (e.g., Spice Level, Add Sauce). Clicking "Place Order" will submit their order. The interface will display the user's current order for the week and the total price. Users are limited to one order per week; attempting to place a second order will be prevented.
+- **Admin View:** Users marked as admins (in the `admin_users` table) can access the admin interface at `/admin.html`. The admin page provides:
+  - **Meal Management:** Add new meals and their descriptions. Add variants (sizes with price and calories) to each meal.
+  - **Option Management:** Create option groups (with flags for required/multi-select) and add option values (with extra costs). These option groups can be linked to meals.
+  - **Pricing Rules:** Define quantity-based discounts for meal variants by specifying a minimum quantity and a discounted price per unit.
+Changes made in the admin interface take effect immediately (they update the D1 database). Regular users will see updated menus or prices as soon as the data is changed.
+
+## Security & Notes
+- Cloudflare Access ensures only authorized users reach the application. The Worker verifies the user email on every request (`cf-access-authenticated-user-email` header).
+- The `admin_users` table controls admin privileges within the app. Non-admin users cannot access admin API routes (the Worker returns 403 Forbidden for those attempts).
+- All important calculations and validations (like total price, discount rules, one-order-per-week enforcement) are performed server-side in the Worker for security.
+- The database uses *immutable versioning* for meals, options, etc. In this simple setup, we always fetch and manipulate the active version of each item. When updating an entity, the intended approach is to insert a new row with an incremented version and mark the old version as inactive (preserving historical data integrity for past orders).

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin - Weekly Lunch Orders</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/admin.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Weekly Lunch Orders</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/index.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "weekly-lunch-orders",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch & wrangler dev"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20230518.0",
+    "@sveltejs/vite-plugin-svelte": "^1.0.0",
+    "autoprefixer": "^10.4.0",
+    "svelte": "^3.55.0",
+    "tailwindcss": "^3.3.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,159 @@
+PRAGMA foreign_keys = ON;
+-- Users table
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE
+);
+-- Admin users table
+CREATE TABLE admin_users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+-- Meals table (versioned)
+CREATE TABLE meals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ref_id INTEGER NOT NULL,
+    version INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    is_active INTEGER NOT NULL,
+    UNIQUE(ref_id, version),
+    UNIQUE(ref_id)
+);
+-- Meal variants table (versioned)
+CREATE TABLE meal_variants (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    meal_ref_id INTEGER NOT NULL,
+    version INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    price INTEGER NOT NULL, -- price in cents
+    calories INTEGER,
+    is_active INTEGER NOT NULL,
+    UNIQUE(meal_ref_id, version, name),
+    FOREIGN KEY(meal_ref_id) REFERENCES meals(ref_id)
+);
+-- Options table (versioned option groups)
+CREATE TABLE options (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ref_id INTEGER NOT NULL,
+    version INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    is_required INTEGER NOT NULL,
+    is_multi_select INTEGER NOT NULL,
+    is_active INTEGER NOT NULL,
+    UNIQUE(ref_id, version),
+    UNIQUE(ref_id)
+);
+-- Option values table (versioned option values)
+CREATE TABLE option_values (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    option_ref_id INTEGER NOT NULL,
+    version INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    extra_cost INTEGER NOT NULL, -- extra cost in cents
+    is_active INTEGER NOT NULL,
+    UNIQUE(option_ref_id, version, name),
+    FOREIGN KEY(option_ref_id) REFERENCES options(ref_id)
+);
+-- Linking table between meals and options
+CREATE TABLE meal_options (
+    meal_ref_id INTEGER NOT NULL,
+    option_ref_id INTEGER NOT NULL,
+    PRIMARY KEY (meal_ref_id, option_ref_id),
+    FOREIGN KEY(meal_ref_id) REFERENCES meals(ref_id) ON DELETE CASCADE,
+    FOREIGN KEY(option_ref_id) REFERENCES options(ref_id) ON DELETE CASCADE
+);
+-- Order weeks table
+CREATE TABLE order_weeks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    week_start_date TEXT NOT NULL,
+    week_end_date TEXT NOT NULL,
+    is_open INTEGER NOT NULL,
+    cutoff_date TEXT NOT NULL
+);
+-- Orders table
+CREATE TABLE orders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    order_week_id INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    total_price INTEGER NOT NULL,
+    FOREIGN KEY(user_id) REFERENCES users(id),
+    FOREIGN KEY(order_week_id) REFERENCES order_weeks(id)
+);
+-- Order items table
+CREATE TABLE order_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id INTEGER NOT NULL,
+    meal_variant_id INTEGER NOT NULL,
+    quantity INTEGER NOT NULL,
+    base_price INTEGER NOT NULL,
+    FOREIGN KEY(order_id) REFERENCES orders(id) ON DELETE CASCADE,
+    FOREIGN KEY(meal_variant_id) REFERENCES meal_variants(id)
+);
+-- Order item options table (selected options for an order item)
+CREATE TABLE order_item_options (
+    order_item_id INTEGER NOT NULL,
+    option_value_id INTEGER NOT NULL,
+    PRIMARY KEY (order_item_id, option_value_id),
+    FOREIGN KEY(order_item_id) REFERENCES order_items(id) ON DELETE CASCADE,
+    FOREIGN KEY(option_value_id) REFERENCES option_values(id)
+);
+-- Meal order pricing rules table
+CREATE TABLE meal_order_pricing_rules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    meal_variant_id INTEGER NOT NULL,
+    min_total_quantity INTEGER NOT NULL,
+    price_per_unit INTEGER NOT NULL,
+    FOREIGN KEY(meal_variant_id) REFERENCES meal_variants(id)
+);
+-- Seed Data
+-- Users and admin users
+INSERT INTO users (name, email) VALUES
+('Alice Admin', 'alice@example.com'),
+('Bob Manager', 'bob@example.com');
+INSERT INTO admin_users (user_id, role, is_active) VALUES
+(1, 'admin', 1),
+(2, 'admin', 1);
+-- Option groups and values
+INSERT INTO options (ref_id, version, name, is_required, is_multi_select, is_active) VALUES
+(1, 1, 'Spice Level', 1, 0, 1),
+(2, 1, 'Add Sauce', 0, 0, 1);
+INSERT INTO option_values (option_ref_id, version, name, extra_cost, is_active) VALUES
+(1, 1, 'Mild', 0, 1),
+(1, 1, 'Medium', 0, 1),
+(1, 1, 'Hot', 0, 1),
+(2, 1, 'BBQ Sauce', 100, 1);
+-- Meals and variants
+INSERT INTO meals (ref_id, version, name, description, is_active) VALUES
+(1, 1, 'Grilled Chicken Salad', 'Fresh salad with grilled chicken, veggies, and dressing', 1),
+(2, 1, 'Beef Taco', 'Spicy ground beef taco with lettuce, tomato, and cheese', 1),
+(3, 1, 'Veggie Pasta', 'Pasta with seasonal vegetables in a light sauce', 1);
+INSERT INTO meal_variants (meal_ref_id, version, name, price, calories, is_active) VALUES
+-- Variants for Meal 1 (Grilled Chicken Salad)
+(1, 1, 'Small', 1000, 300, 1),
+(1, 1, 'Medium', 1500, 450, 1),
+(1, 1, 'Large', 2000, 600, 1),
+-- Variants for Meal 2 (Beef Taco)
+(2, 1, 'Small', 800, 250, 1),
+(2, 1, 'Medium', 1200, 400, 1),
+(2, 1, 'Large', 1600, 550, 1),
+-- Variants for Meal 3 (Veggie Pasta)
+(3, 1, 'Small', 900, 200, 1),
+(3, 1, 'Medium', 1300, 350, 1),
+(3, 1, 'Large', 1700, 500, 1);
+-- Link option groups to meals
+INSERT INTO meal_options (meal_ref_id, option_ref_id) VALUES
+(1, 1), (1, 2),
+(2, 1), (2, 2),
+(3, 1), (3, 2);
+-- Active order week
+INSERT INTO order_weeks (week_start_date, week_end_date, is_open, cutoff_date) VALUES
+('2025-06-30', '2025-07-04', 1, '2025-07-02');
+-- Sample pricing rule (e.g., discount for bulk order of Small Grilled Chicken Salad)
+INSERT INTO meal_order_pricing_rules (meal_variant_id, min_total_quantity, price_per_unit) VALUES
+(1, 3, 900);

--- a/src/admin.js
+++ b/src/admin.js
@@ -1,0 +1,6 @@
+import './global.css';
+import Admin from './admin.svelte';
+const app = new Admin({
+  target: document.getElementById('app')
+});
+export default app;

--- a/src/admin.svelte
+++ b/src/admin.svelte
@@ -1,0 +1,357 @@
+<script>
+import { onMount } from 'svelte';
+let adminMeals = [];
+let adminOptions = [];
+let pricingRules = [];
+let variantChoices = []; // combined list of variants for dropdown
+let message = '';
+let errorMsg = '';
+// Form fields for admin actions
+let newMealName = '';
+let newMealDesc = '';
+let selectedMealForVariant = '';
+let newVariantName = '';
+let newVariantPrice = 0;
+let newVariantCalories = 0;
+let newOptionName = '';
+let newOptionRequired = false;
+let newOptionMulti = false;
+let selectedOptionGroup = '';
+let newOptionValueName = '';
+let newOptionValueCost = 0;
+let linkMealRef = '';
+let linkOptionRef = '';
+let selectedVariantForRule = '';
+let newRuleMinQty = 0;
+let newRulePrice = 0;
+async function loadAdminMeals() {
+  const res = await fetch('/api/admin/meals');
+  const data = await res.json();
+  adminMeals = data.meals || [];
+}
+async function loadAdminOptions() {
+  const res = await fetch('/api/admin/options');
+  const data = await res.json();
+  adminOptions = data.options || [];
+}
+async function loadPricingRules() {
+  const res = await fetch('/api/admin/pricing-rules');
+  const data = await res.json();
+  pricingRules = data.pricing_rules || [];
+}
+onMount(async () => {
+  try {
+    await Promise.all([loadAdminMeals(), loadAdminOptions(), loadPricingRules()]);
+  } catch (e) {
+    errorMsg = 'Failed to load admin data.';
+  }
+});
+// Reactive: update variant choices list whenever adminMeals changes
+$: {
+  variantChoices = [];
+  for (const meal of adminMeals) {
+    if (meal.variants) {
+      for (const variant of meal.variants) {
+        variantChoices.push({ id: variant.id, label: meal.name + ' - ' + variant.name });
+      }
+    }
+  }
+}
+// Admin action functions
+async function createMeal() {
+  errorMsg = '';
+  message = '';
+  if (!newMealName) {
+    errorMsg = 'Meal name is required';
+    return;
+  }
+  try {
+    const res = await fetch('/api/admin/meals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: newMealName, description: newMealDesc })
+    });
+    const result = await res.json();
+    if (!res.ok) {
+      errorMsg = result.error || 'Failed to add meal';
+    } else {
+      message = 'Meal added successfully';
+      newMealName = '';
+      newMealDesc = '';
+      await loadAdminMeals();
+    }
+  } catch (e) {
+    errorMsg = 'Failed to add meal';
+  }
+}
+async function createVariant() {
+  errorMsg = '';
+  message = '';
+  if (!selectedMealForVariant || !newVariantName) {
+    errorMsg = 'Please select a meal and enter variant name';
+    return;
+  }
+  try {
+    const priceVal = parseInt(newVariantPrice);
+    const calVal = parseInt(newVariantCalories);
+    const res = await fetch('/api/admin/variants', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        meal_ref_id: parseInt(selectedMealForVariant),
+        name: newVariantName,
+        price: isNaN(priceVal) ? 0 : priceVal,
+        calories: isNaN(calVal) ? 0 : calVal
+      })
+    });
+    const result = await res.json();
+    if (!res.ok) {
+      errorMsg = result.error || 'Failed to add variant';
+    } else {
+      message = 'Variant added successfully';
+      selectedMealForVariant = '';
+      newVariantName = '';
+      newVariantPrice = 0;
+      newVariantCalories = 0;
+      await loadAdminMeals();
+    }
+  } catch (e) {
+    errorMsg = 'Failed to add variant';
+  }
+}
+async function createOptionGroup() {
+  errorMsg = '';
+  message = '';
+  if (!newOptionName) {
+    errorMsg = 'Option group name is required';
+    return;
+  }
+  try {
+    const res = await fetch('/api/admin/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: newOptionName,
+        is_required: newOptionRequired,
+        is_multi_select: newOptionMulti
+      })
+    });
+    const result = await res.json();
+    if (!res.ok) {
+      errorMsg = result.error || 'Failed to add option group';
+    } else {
+      message = 'Option group added successfully';
+      newOptionName = '';
+      newOptionRequired = false;
+      newOptionMulti = false;
+      await loadAdminOptions();
+    }
+  } catch (e) {
+    errorMsg = 'Failed to add option group';
+  }
+}
+async function createOptionValue() {
+  errorMsg = '';
+  message = '';
+  if (!selectedOptionGroup || !newOptionValueName) {
+    errorMsg = 'Please select an option group and enter a value name';
+    return;
+  }
+  try {
+    const costVal = parseInt(newOptionValueCost);
+    const res = await fetch('/api/admin/option-values', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        option_ref_id: parseInt(selectedOptionGroup),
+        name: newOptionValueName,
+        extra_cost: isNaN(costVal) ? 0 : costVal
+      })
+    });
+    const result = await res.json();
+    if (!res.ok) {
+      errorMsg = result.error || 'Failed to add option value';
+    } else {
+      message = 'Option value added successfully';
+      newOptionValueName = '';
+      newOptionValueCost = 0;
+      await loadAdminOptions();
+    }
+  } catch (e) {
+    errorMsg = 'Failed to add option value';
+  }
+}
+async function linkOptionToMeal() {
+  errorMsg = '';
+  message = '';
+  if (!linkMealRef || !linkOptionRef) {
+    errorMsg = 'Select a meal and option group to link';
+    return;
+  }
+  try {
+    const res = await fetch('/api/admin/meal-options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        meal_ref_id: parseInt(linkMealRef),
+        option_ref_id: parseInt(linkOptionRef)
+      })
+    });
+    const result = await res.json();
+    if (!res.ok) {
+      errorMsg = result.error || 'Failed to link option';
+    } else {
+      message = 'Option group linked to meal';
+      linkMealRef = '';
+      linkOptionRef = '';
+      await loadAdminMeals();
+    }
+  } catch (e) {
+    errorMsg = 'Failed to link option';
+  }
+}
+async function createPricingRule() {
+  errorMsg = '';
+  message = '';
+  if (!selectedVariantForRule || newRuleMinQty <= 0 || newRulePrice <= 0) {
+    errorMsg = 'All pricing rule fields are required';
+    return;
+  }
+  try {
+    const res = await fetch('/api/admin/pricing-rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        meal_variant_id: parseInt(selectedVariantForRule),
+        min_total_quantity: parseInt(newRuleMinQty),
+        price_per_unit: parseInt(newRulePrice)
+      })
+    });
+    const result = await res.json();
+    if (!res.ok) {
+      errorMsg = result.error || 'Failed to add pricing rule';
+    } else {
+      message = 'Pricing rule added successfully';
+      selectedVariantForRule = '';
+      newRuleMinQty = 0;
+      newRulePrice = 0;
+      await loadPricingRules();
+    }
+  } catch (e) {
+    errorMsg = 'Failed to add pricing rule';
+  }
+}
+</script>
+{#if errorMsg}
+<p class="text-red-600 font-semibold">{errorMsg}</p>
+{/if}
+{#if message}
+<p class="text-green-600 font-semibold">{message}</p>
+{/if}
+<h2 class="text-2xl font-bold mt-4 mb-2">Meals & Variants</h2>
+<ul class="mb-4">
+{#each adminMeals as meal}
+<li class="mb-2">
+<strong>{meal.name}</strong> – {meal.description} {#if !meal.is_active}(inactive){/if}
+<ul class="ml-4">
+{#each meal.variants as v}
+<li>{v.name}: ${ (v.price / 100).toFixed(2) } – {v.calories} cal {#if !v.is_active}(inactive){/if}</li>
+{/each}
+</ul>
+{#if meal.options.length > 0}
+<p class="ml-4 text-sm text-gray-700">Options: {meal.options.map(o => o.name).join(', ')}</p>
+{/if}
+</li>
+{/each}
+</ul>
+<div class="mb-4">
+<h3 class="font-semibold">Add New Meal</h3>
+<input type="text" placeholder="Meal name" bind:value={newMealName} class="border px-2 py-1 mr-2" />
+<input type="text" placeholder="Description" bind:value={newMealDesc} class="border px-2 py-1 mr-2" />
+<button class="bg-blue-600 text-white px-3 py-1 rounded" on:click={createMeal}>Add Meal</button>
+</div>
+<div class="mb-4">
+<h3 class="font-semibold">Add Variant to Meal</h3>
+<select bind:value={selectedMealForVariant} class="border px-2 py-1 mr-2">
+<option value="" disabled selected>Select meal</option>
+{#each adminMeals as meal}
+<option value={meal.ref_id}>{meal.name}</option>
+{/each}
+</select>
+<input type="text" placeholder="Variant name" bind:value={newVariantName} class="border px-2 py-1 mr-2" />
+<input type="number" placeholder="Price (cents)" bind:value={newVariantPrice} class="border px-2 py-1 mr-2 w-28" />
+<input type="number" placeholder="Calories" bind:value={newVariantCalories} class="border px-2 py-1 mr-2 w-20" />
+<button class="bg-blue-600 text-white px-3 py-1 rounded" on:click={createVariant}>Add Variant</button>
+</div>
+<div class="mb-6">
+<h3 class="font-semibold">Assign Option Group to Meal</h3>
+<select bind:value={linkMealRef} class="border px-2 py-1 mr-2">
+<option value="" disabled selected>Select meal</option>
+{#each adminMeals as meal}
+<option value={meal.ref_id}>{meal.name}</option>
+{/each}
+</select>
+<select bind:value={linkOptionRef} class="border px-2 py-1 mr-2">
+<option value="" disabled selected>Select option group</option>
+{#each adminOptions as opt}
+<option value={opt.ref_id}>{opt.name}</option>
+{/each}
+</select>
+<button class="bg-blue-600 text-white px-3 py-1 rounded" on:click={linkOptionToMeal}>Link Option</button>
+</div>
+<h2 class="text-2xl font-bold mb-2">Option Groups & Values</h2>
+<ul class="mb-4">
+{#each adminOptions as opt}
+<li class="mb-2">
+<strong>{opt.name}</strong>
+{#if opt.is_required} (required){/if}{#if opt.is_multi_select} (multiselect){/if} {#if !opt.is_active}(inactive){/if}
+<ul class="ml-4">
+{#each opt.values as val}
+<li>{val.name}{#if val.extra_cost > 0} (+${(val.extra_cost / 100).toFixed(2)}){/if} {#if !val.is_active}(inactive){/if}</li>
+{/each}
+</ul>
+</li>
+{/each}
+</ul>
+<div class="mb-4">
+<h3 class="font-semibold">Add Option Group</h3>
+<input type="text" placeholder="Group name" bind:value={newOptionName} class="border px-2 py-1 mr-2" />
+<label class="mr-2"><input type="checkbox" bind:checked={newOptionRequired} /> Required</label>
+<label class="mr-2"><input type="checkbox" bind:checked={newOptionMulti} /> Multi-select</label>
+<button class="bg-blue-600 text-white px-3 py-1 rounded" on:click={createOptionGroup}>Add Group</button>
+</div>
+<div class="mb-6">
+<h3 class="font-semibold">Add Option Value</h3>
+<select bind:value={selectedOptionGroup} class="border px-2 py-1 mr-2">
+<option value="" disabled selected>Select group</option>
+{#each adminOptions as opt}
+<option value={opt.ref_id}>{opt.name}</option>
+{/each}
+</select>
+<input type="text" placeholder="Value name" bind:value={newOptionValueName} class="border px-2 py-1 mr-2" />
+<input type="number" placeholder="Extra cost (cents)" bind:value={newOptionValueCost} class="border px-2 py-1 mr-2 w-28" />
+<button class="bg-blue-600 text-white px-3 py-1 rounded" on:click={createOptionValue}>Add Value</button>
+</div>
+<h2 class="text-2xl font-bold mb-2">Pricing Rules</h2>
+<table class="mb-4 text-left border-collapse">
+<tr><th class="p-1 border-b">Meal - Variant</th><th class="p-1 border-b">Min Qty</th><th class="p-1 border-b">Price per Unit</th></tr>
+{#each pricingRules as rule}
+<tr>
+<td class="p-1 border-b">{rule.meal_name} – {rule.variant_name}</td>
+<td class="p-1 border-b">{rule.min_total_quantity}</td>
+<td class="p-1 border-b">${ (rule.price_per_unit / 100).toFixed(2) }</td>
+</tr>
+{/each}
+</table>
+<div class="mb-6">
+<h3 class="font-semibold">Add Pricing Rule</h3>
+<select bind:value={selectedVariantForRule} class="border px-2 py-1 mr-2">
+<option value="" disabled selected>Select variant</option>
+{#each variantChoices as choice}
+<option value={choice.id}>{choice.label}</option>
+{/each}
+</select>
+<input type="number" placeholder="Min quantity" bind:value={newRuleMinQty} class="border px-2 py-1 mr-2 w-20" />
+<input type="number" placeholder="Price per unit (cents)" bind:value={newRulePrice} class="border px-2 py-1 mr-2 w-28" />
+<button class="bg-blue-600 text-white px-3 py-1 rounded" on:click={createPricingRule}>Add Rule</button>
+</div>

--- a/src/global.css
+++ b/src/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+import './global.css';
+import Index from './index.svelte';
+const app = new Index({
+  target: document.getElementById('app')
+});
+export default app;

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -1,0 +1,193 @@
+<script>
+import { onMount } from 'svelte';
+let menu = null;
+let currentOrder = null;
+let orderSelections = {};
+let isLoading = true;
+let errorMsg = '';
+let successMsg = '';
+onMount(async () => {
+  try {
+    // Fetch weekly menu data
+    const res = await fetch('/api/meals');
+    const data = await res.json();
+    menu = data;
+    // Initialize selection structure for each variant
+    orderSelections = {};
+    if (menu && menu.meals) {
+      for (const meal of menu.meals) {
+        for (const variant of meal.variants) {
+          orderSelections[variant.id] = { quantity: 0, options: {} };
+          if (meal.options) {
+            for (const opt of meal.options) {
+              if (opt.is_multi_select) {
+                orderSelections[variant.id].options[opt.id] = [];
+              } else {
+                orderSelections[variant.id].options[opt.id] = opt.is_required && opt.values.length ? opt.values[0].id : null;
+              }
+            }
+          }
+        }
+      }
+    }
+    // Fetch current order (if any)
+    const orderRes = await fetch('/api/order');
+    const orderData = await orderRes.json();
+    currentOrder = orderData.order;
+  } catch (e) {
+    errorMsg = 'Failed to load menu.';
+  } finally {
+    isLoading = false;
+  }
+});
+async function placeOrder() {
+  errorMsg = '';
+  successMsg = '';
+  // Build order items from selections
+  const items = [];
+  if (menu && menu.meals) {
+    for (const meal of menu.meals) {
+      for (const variant of meal.variants) {
+        const sel = orderSelections[variant.id];
+        if (sel.quantity > 0) {
+          const selectedOptionValues = [];
+          if (meal.options) {
+            for (const opt of meal.options) {
+              if (opt.is_multi_select) {
+                selectedOptionValues.push(...sel.options[opt.id]);
+              } else {
+                const val = sel.options[opt.id];
+                if (val) selectedOptionValues.push(val);
+              }
+            }
+          }
+          items.push({ meal_variant_id: variant.id, quantity: sel.quantity, options: selectedOptionValues });
+        }
+      }
+    }
+  }
+  if (items.length === 0) {
+    errorMsg = 'Please select at least one item.';
+    return;
+  }
+  // Submit order
+  try {
+    const res = await fetch('/api/order', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ items })
+    });
+    const result = await res.json();
+    if (!res.ok) {
+      errorMsg = result.error || 'Failed to place order.';
+    } else {
+      successMsg = 'Order placed successfully!';
+      // Refresh current order details
+      const orderRes = await fetch('/api/order');
+      const orderData = await orderRes.json();
+      currentOrder = orderData.order;
+    }
+  } catch (e) {
+    errorMsg = 'Failed to place order.';
+  }
+}
+</script>
+{#if isLoading}
+<p class="text-gray-600">Loading menu...</p>
+{/if}
+{#if !isLoading}
+{#if menu && menu.week}
+<h1 class="text-2xl font-bold mb-4">Weekly Menu (Week of {menu.week.week_start_date})</h1>
+{#if !menu.week.is_open}
+<p class="text-red-600 mb-4">Ordering is closed for this week.</p>
+{/if}
+{/if}
+{#if menu}
+{#each menu.meals as meal}
+<div class="mb-6 pb-4 border-b">
+<h2 class="text-xl font-semibold">{meal.name}</h2>
+<p class="text-gray-700 mb-2">{meal.description}</p>
+{#each meal.variants as variant}
+<div class="ml-4 mb-3">
+<div class="flex items-center space-x-4">
+<span class="font-medium">{variant.name} – ${ (variant.price / 100).toFixed(2) }</span>
+<span class="text-sm text-gray-600">{variant.calories} cal</span>
+<label class="ml-4 text-sm">
+Qty:
+<input type="number" min="0" max="10" class="w-16 border px-1 py-0.5" bind:value={orderSelections[variant.id].quantity} />
+</label>
+</div>
+{#each meal.options as opt}
+<div class="ml-6 text-sm">
+{#if opt.is_multi_select}
+<span class="font-medium">{opt.name}:</span>
+{#each opt.values as val}
+<label class="ml-2">
+<input type="checkbox" bind:group={orderSelections[variant.id].options[opt.id]} value={val.id} />
+{val.name}{#if val.extra_cost > 0} (+${(val.extra_cost / 100).toFixed(2)}){/if}
+</label>
+{/each}
+{:else}
+{#if !opt.is_required && opt.values.length === 1}
+<!-- Single optional value as checkbox -->
+<label>
+<input type="checkbox" on:change={() => { const current = orderSelections[variant.id].options[opt.id]; orderSelections[variant.id].options[opt.id] = current ? null : opt.values[0].id; }} checked={orderSelections[variant.id].options[opt.id]} />
+{opt.values[0].name}{#if opt.values[0].extra_cost > 0} (+${(opt.values[0].extra_cost / 100).toFixed(2)}){/if}
+</label>
+{:else}
+<label class="font-medium">{opt.name}:</label>
+{#if opt.values.length > 1}
+<select bind:value={orderSelections[variant.id].options[opt.id]} class="ml-2 border">
+<option value={null}>None</option>
+{#each opt.values as val}
+<option value={val.id}>{val.name}{#if val.extra_cost > 0} (+${(val.extra_cost / 100).toFixed(2)}){/if}</option>
+{/each}
+</select>
+{:else}
+<!-- Only one possible value (required) -->
+<span class="ml-2">{opt.values[0].name}</span>
+<input type="hidden" value={opt.values[0].id} bind:value={orderSelections[variant.id].options[opt.id]} />
+{/if}
+{/if}
+{/if}
+</div>
+{/each}
+</div>
+{/each}
+</div>
+{/each}
+{/if}
+<!-- Current Order Summary -->
+{#if currentOrder}
+<h2 class="text-xl font-semibold mt-6 mb-2">Your Order for This Week:</h2>
+<ul class="mb-4">
+{#each currentOrder.items as item}
+<li class="mb-1">{item.quantity}× {item.meal_name} – {item.variant_name}
+{#if item.options && item.options.length > 0}
+<ul class="ml-4 text-gray-700 text-sm">
+{#each item.options as opt}
+<li>{opt.option_name}: {opt.value_name}{#if opt.extra_cost > 0} (+${(opt.extra_cost / 100).toFixed(2)}){/if}</li>
+{/each}
+</ul>
+{/if}
+</li>
+{/each}
+</ul>
+<p class="font-medium">Total: ${ (currentOrder.total_price / 100).toFixed(2) }</p>
+{#if currentOrder.status === 'placed'}
+<p class="text-green-600 font-semibold mt-2">Your order has been placed.</p>
+{:else}
+<p class="text-yellow-600 font-semibold mt-2">Order saved (not yet submitted).</p>
+{/if}
+{/if}
+<!-- Order Submission -->
+{#if menu && menu.week && menu.week.is_open && !(currentOrder && currentOrder.status === 'placed')}
+{#if errorMsg}
+<p class="text-red-600 mb-2">{errorMsg}</p>
+{/if}
+{#if successMsg}
+<p class="text-green-600 mb-2">{successMsg}</p>
+{/if}
+<button class="px-4 py-2 bg-blue-600 text-white font-semibold rounded" on:click|preventDefault={placeOrder}>Place Order</button>
+{/if}
+{/if}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,320 @@
+export interface Env {
+  DB: any; // D1Database binding
+  ASSETS: { fetch: (req: Request) => Promise<Response> };
+}
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    const path = url.pathname;
+    const method = request.method;
+    // Require authentication via Cloudflare Access
+    const userEmail = request.headers.get('cf-access-authenticated-user-email');
+    if (!userEmail) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+    // Ensure user exists in database (create if not)
+    let user = await env.DB.prepare('SELECT id, name FROM users WHERE email = ?').bind(userEmail).first();
+    if (!user) {
+      const username = userEmail.split('@')[0] || 'User';
+      await env.DB.prepare('INSERT INTO users (name, email) VALUES (?, ?)').bind(username, userEmail).run();
+      user = await env.DB.prepare('SELECT id, name FROM users WHERE email = ?').bind(userEmail).first();
+    }
+    const userId = user.id;
+    // Check if user is an admin
+    const adminRecord = await env.DB.prepare('SELECT id FROM admin_users WHERE user_id = ? AND is_active = 1').bind(userId).first();
+    const isAdmin = !!adminRecord;
+    // Redirect /admin to /admin.html for the admin interface
+    if (path === '/admin') {
+      return Response.redirect(`${url.origin}/admin.html`, 302);
+    }
+    // Public API endpoints
+    // Get basic user info (including admin flag)
+    if (path === '/api/me' && method === 'GET') {
+      const info = { name: user.name, email: userEmail, isAdmin: isAdmin };
+      return new Response(JSON.stringify(info), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    // Get weekly menu and meals
+    if (path === '/api/meals' && method === 'GET') {
+      // Find current open order week
+      const week = await env.DB.prepare('SELECT * FROM order_weeks WHERE is_open = 1 LIMIT 1').first();
+      if (!week) {
+        return new Response(JSON.stringify({ week: null, meals: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Determine if ordering is still open (check cutoff date)
+      const todayStr = new Date().toISOString().split('T')[0];
+      if (todayStr > week.cutoff_date) {
+        week.is_open = 0; // treat as closed if past cutoff
+      }
+      // Fetch active meals and their variants/options
+      const mealsResult = await env.DB.prepare('SELECT id, ref_id, name, description FROM meals WHERE is_active = 1').all();
+      const mealsList = mealsResult.results || [];
+      for (const meal of mealsList) {
+        // Active variants for the meal
+        const varsResult = await env.DB.prepare('SELECT id, name, price, calories FROM meal_variants WHERE meal_ref_id = ? AND is_active = 1').bind(meal.ref_id).all();
+        meal.variants = varsResult.results || [];
+        // Option groups linked to the meal
+        meal.options = [];
+        const optsLinkRes = await env.DB.prepare('SELECT option_ref_id FROM meal_options WHERE meal_ref_id = ?').bind(meal.ref_id).all();
+        const optionRefs = optsLinkRes.results ? optsLinkRes.results.map((o: any) => o.option_ref_id) : [];
+        for (const optRef of optionRefs) {
+          const opt = await env.DB.prepare('SELECT id, name, is_required, is_multi_select FROM options WHERE ref_id = ? AND is_active = 1').bind(optRef).first();
+          if (!opt) continue;
+          const valsRes = await env.DB.prepare('SELECT id, name, extra_cost FROM option_values WHERE option_ref_id = ? AND is_active = 1').bind(optRef).all();
+          opt.values = valsRes.results || [];
+          meal.options.push(opt);
+        }
+      }
+      const responseData = {
+        week: {
+          id: week.id,
+          week_start_date: week.week_start_date,
+          week_end_date: week.week_end_date,
+          is_open: week.is_open,
+          cutoff_date: week.cutoff_date
+        },
+        meals: mealsList
+      };
+      return new Response(JSON.stringify(responseData), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    // Get current user's order for the week (if any)
+    if (path === '/api/order' && method === 'GET') {
+      const week = await env.DB.prepare('SELECT id FROM order_weeks WHERE is_open = 1 LIMIT 1').first();
+      if (!week) {
+        return new Response(JSON.stringify({ order: null }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      const order = await env.DB.prepare('SELECT id, status, total_price FROM orders WHERE user_id = ? AND order_week_id = ?').bind(userId, week.id).first();
+      if (!order) {
+        return new Response(JSON.stringify({ order: null }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Fetch order items
+      const itemsRes = await env.DB.prepare('SELECT id, meal_variant_id, quantity, base_price FROM order_items WHERE order_id = ?').bind(order.id).all();
+      const items = itemsRes.results || [];
+      for (const item of items) {
+        // Get variant and meal names for display
+        const variant = await env.DB.prepare('SELECT name, meal_ref_id FROM meal_variants WHERE id = ?').bind(item.meal_variant_id).first();
+        item.variant_name = variant ? variant.name : '';
+        if (variant) {
+          const meal = await env.DB.prepare('SELECT name FROM meals WHERE ref_id = ? AND is_active = 1').bind(variant.meal_ref_id).first();
+          item.meal_name = meal ? meal.name : '';
+        }
+        // Get selected options for this item
+        const optsRes = await env.DB.prepare(
+          'SELECT o.name AS option_name, ov.name AS value_name, ov.extra_cost AS extra_cost ' +
+          'FROM order_item_options oio ' +
+          'JOIN option_values ov ON oio.option_value_id = ov.id ' +
+          'JOIN options o ON ov.option_ref_id = o.ref_id ' +
+          'WHERE oio.order_item_id = ?'
+        ).bind(item.id).all();
+        item.options = optsRes.results || [];
+        // Calculate line total (base price + extras) * quantity
+        let extrasTotal = 0;
+        for (const opt of item.options) {
+          extrasTotal += opt.extra_cost;
+        }
+        const unitPrice = item.base_price + extrasTotal;
+        item.line_total = unitPrice * item.quantity;
+      }
+      order.items = items;
+      return new Response(JSON.stringify({ order: order }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    // Place or update an order for the current week
+    if (path === '/api/order' && method === 'POST') {
+      const week = await env.DB.prepare('SELECT * FROM order_weeks WHERE is_open = 1 LIMIT 1').first();
+      if (!week || !week.is_open) {
+        return new Response(JSON.stringify({ error: 'Ordering is not open' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+      const todayStr = new Date().toISOString().split('T')[0];
+      if (todayStr > week.cutoff_date) {
+        return new Response(JSON.stringify({ error: 'Order period has closed' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Enforce one order per user per week
+      const existingOrder = await env.DB.prepare('SELECT id, status FROM orders WHERE user_id = ? AND order_week_id = ?').bind(userId, week.id).first();
+      if (existingOrder && existingOrder.status === 'placed') {
+        return new Response(JSON.stringify({ error: 'You have already placed an order this week' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (existingOrder && existingOrder.status === 'cart') {
+        // Remove existing cart to replace with new order
+        await env.DB.prepare('DELETE FROM order_item_options WHERE order_item_id IN (SELECT id FROM order_items WHERE order_id = ?)').bind(existingOrder.id).run();
+        await env.DB.prepare('DELETE FROM order_items WHERE order_id = ?').bind(existingOrder.id).run();
+        await env.DB.prepare('DELETE FROM orders WHERE id = ?').bind(existingOrder.id).run();
+      }
+      const data = await request.json();
+      const items = data.items || [];
+      if (!items.length) {
+        return new Response(JSON.stringify({ error: 'No items in order' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Create a new order in "cart" status
+      await env.DB.prepare('INSERT INTO orders (user_id, order_week_id, status, total_price) VALUES (?, ?, ?, ?)').bind(userId, week.id, 'cart', 0).run();
+      const newOrderRes = await env.DB.prepare('SELECT last_insert_rowid() as orderId').first();
+      const orderId = newOrderRes.orderId;
+      let orderTotal = 0;
+      // Calculate total quantities per variant for discount rules
+      const totalQtyByVariant: Record<number, number> = {};
+      for (const item of items) {
+        totalQtyByVariant[item.meal_variant_id] = (totalQtyByVariant[item.meal_variant_id] || 0) + item.quantity;
+      }
+      // Insert order items and options
+      for (const item of items) {
+        const variantId = item.meal_variant_id;
+        const quantity = item.quantity;
+        // Fetch base price of the variant
+        const variantRow = await env.DB.prepare('SELECT price FROM meal_variants WHERE id = ?').bind(variantId).first();
+        if (!variantRow) continue;
+        let basePrice = variantRow.price;
+        // Apply pricing rule if threshold met
+        const rule = await env.DB.prepare(
+          'SELECT price_per_unit FROM meal_order_pricing_rules ' +
+          'WHERE meal_variant_id = ? AND min_total_quantity <= ? ' +
+          'ORDER BY min_total_quantity DESC LIMIT 1'
+        ).bind(variantId, totalQtyByVariant[variantId] || quantity).first();
+        if (rule) {
+          basePrice = rule.price_per_unit;
+        }
+        // Insert order item
+        await env.DB.prepare('INSERT INTO order_items (order_id, meal_variant_id, quantity, base_price) VALUES (?, ?, ?, ?)').bind(orderId, variantId, quantity, basePrice).run();
+        const newItemRes = await env.DB.prepare('SELECT last_insert_rowid() as itemId').first();
+        const orderItemId = newItemRes.itemId;
+        // Calculate extra cost for selected options
+        let extrasCost = 0;
+        if (item.options && Array.isArray(item.options)) {
+          for (const optionValueId of item.options) {
+            const optVal = await env.DB.prepare('SELECT extra_cost FROM option_values WHERE id = ?').bind(optionValueId).first();
+            const extra = optVal ? optVal.extra_cost : 0;
+            await env.DB.prepare('INSERT INTO order_item_options (order_item_id, option_value_id) VALUES (?, ?)').bind(orderItemId, optionValueId).run();
+            extrasCost += extra;
+          }
+        }
+        const itemTotal = (basePrice + extrasCost) * quantity;
+        orderTotal += itemTotal;
+      }
+      // Update order status to "placed" and set total price
+      await env.DB.prepare('UPDATE orders SET status = ?, total_price = ? WHERE id = ?').bind('placed', orderTotal, orderId).run();
+      return new Response(JSON.stringify({ orderId: orderId, status: 'placed' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    // Admin API endpoints (require admin privileges)
+    if (path.startsWith('/api/admin')) {
+      if (!isAdmin) {
+        return new Response('Forbidden', { status: 403 });
+      }
+      // List meals (and their variants & linked options)
+      if (path === '/api/admin/meals' && method === 'GET') {
+        const mealsRes = await env.DB.prepare('SELECT id, ref_id, name, description, is_active, version FROM meals WHERE is_active = 1').all();
+        const meals = mealsRes.results || [];
+        for (const meal of meals) {
+          const variantsRes = await env.DB.prepare('SELECT id, name, price, calories, is_active, version FROM meal_variants WHERE meal_ref_id = ? AND is_active = 1').bind(meal.ref_id).all();
+          meal.variants = variantsRes.results || [];
+          const optsRes = await env.DB.prepare(
+            'SELECT o.id, o.name FROM meal_options mo ' +
+            'JOIN options o ON mo.option_ref_id = o.ref_id AND o.is_active = 1 ' +
+            'WHERE mo.meal_ref_id = ?'
+          ).bind(meal.ref_id).all();
+          meal.options = optsRes.results || [];
+        }
+        return new Response(JSON.stringify({ meals: meals }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Create a new meal
+      if (path === '/api/admin/meals' && method === 'POST') {
+        const body = await request.json();
+        const name = body.name;
+        const description = body.description || '';
+        if (!name) {
+          return new Response(JSON.stringify({ error: 'Meal name is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+        }
+        const refRes = await env.DB.prepare('SELECT IFNULL(MAX(ref_id), 0) + 1 as newRef FROM meals').first();
+        const newRef = refRes.newRef;
+        await env.DB.prepare('INSERT INTO meals (ref_id, version, name, description, is_active) VALUES (?, ?, ?, ?, ?)').bind(newRef, 1, name, description, 1).run();
+        return new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Add a new meal variant
+      if (path === '/api/admin/variants' && method === 'POST') {
+        const body = await request.json();
+        const mealRef = body.meal_ref_id;
+        const name = body.name;
+        const price = body.price;
+        const calories = body.calories || 0;
+        if (!mealRef || !name || price == null) {
+          return new Response(JSON.stringify({ error: 'Missing variant fields' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+        }
+        await env.DB.prepare('INSERT INTO meal_variants (meal_ref_id, version, name, price, calories, is_active) VALUES (?, ?, ?, ?, ?, ?)').bind(mealRef, 1, name, price, calories, 1).run();
+        return new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Create a new option group
+      if (path === '/api/admin/options' && method === 'POST') {
+        const body = await request.json();
+        const name = body.name;
+        const isRequired = body.is_required ? 1 : 0;
+        const isMulti = body.is_multi_select ? 1 : 0;
+        if (!name) {
+          return new Response(JSON.stringify({ error: 'Option name is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+        }
+        const refRes = await env.DB.prepare('SELECT IFNULL(MAX(ref_id), 0) + 1 as newRef FROM options').first();
+        const newRef = refRes.newRef;
+        await env.DB.prepare('INSERT INTO options (ref_id, version, name, is_required, is_multi_select, is_active) VALUES (?, ?, ?, ?, ?, ?)').bind(newRef, 1, name, isRequired, isMulti, 1).run();
+        return new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Add a new option value
+      if (path === '/api/admin/option-values' && method === 'POST') {
+        const body = await request.json();
+        const optionRef = body.option_ref_id;
+        const name = body.name;
+        let extraCost = body.extra_cost;
+        if (extraCost == null || extraCost === '') extraCost = 0;
+        if (!optionRef || !name) {
+          return new Response(JSON.stringify({ error: 'Missing option value fields' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+        }
+        await env.DB.prepare('INSERT INTO option_values (option_ref_id, version, name, extra_cost, is_active) VALUES (?, ?, ?, ?, ?)').bind(optionRef, 1, name, extraCost, 1).run();
+        return new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Link an option group to a meal
+      if (path === '/api/admin/meal-options' && method === 'POST') {
+        const body = await request.json();
+        const mealRef = body.meal_ref_id;
+        const optionRef = body.option_ref_id;
+        if (!mealRef || !optionRef) {
+          return new Response(JSON.stringify({ error: 'Missing meal or option reference' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+        }
+        try {
+          await env.DB.prepare('INSERT INTO meal_options (meal_ref_id, option_ref_id) VALUES (?, ?)').bind(mealRef, optionRef).run();
+        } catch (e) {
+          // Ignore duplicate linking
+        }
+        return new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Create a new pricing rule
+      if (path === '/api/admin/pricing-rules' && method === 'POST') {
+        const body = await request.json();
+        const variantId = body.meal_variant_id;
+        const minQty = body.min_total_quantity;
+        const pricePerUnit = body.price_per_unit;
+        if (!variantId || minQty == null || pricePerUnit == null) {
+          return new Response(JSON.stringify({ error: 'Missing pricing rule fields' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+        }
+        await env.DB.prepare('INSERT INTO meal_order_pricing_rules (meal_variant_id, min_total_quantity, price_per_unit) VALUES (?, ?, ?)').bind(variantId, minQty, pricePerUnit).run();
+        return new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // List all option groups (with their values)
+      if (path === '/api/admin/options' && method === 'GET') {
+        const optsRes = await env.DB.prepare('SELECT id, ref_id, name, is_required, is_multi_select, is_active, version FROM options WHERE is_active = 1').all();
+        const options = optsRes.results || [];
+        for (const opt of options) {
+          const valsRes = await env.DB.prepare('SELECT id, name, extra_cost, is_active, version FROM option_values WHERE option_ref_id = ? AND is_active = 1').bind(opt.ref_id).all();
+          opt.values = valsRes.results || [];
+        }
+        return new Response(JSON.stringify({ options: options }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // List all pricing rules
+      if (path === '/api/admin/pricing-rules' && method === 'GET') {
+        const rulesRes = await env.DB.prepare(
+          'SELECT r.id, r.meal_variant_id, r.min_total_quantity, r.price_per_unit, ' +
+          'v.name AS variant_name, m.name AS meal_name ' +
+          'FROM meal_order_pricing_rules r ' +
+          'JOIN meal_variants v ON r.meal_variant_id = v.id AND v.is_active = 1 ' +
+          'JOIN meals m ON v.meal_ref_id = m.ref_id AND m.is_active = 1'
+        ).all();
+        return new Response(JSON.stringify({ pricing_rules: rulesRes.results || [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+    }
+    // For any other request, serve static assets
+    return env.ASSETS.fetch(request);
+  }
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./src/**/*.{html,svelte,js,ts}"],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import path from 'path';
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        admin: path.resolve(__dirname, 'admin.html')
+      }
+    }
+  }
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,11 @@
+name = "weekly-lunch-orders"
+account_id = "YOUR_ACCOUNT_ID"
+main = "src/worker.ts"
+compatibility_date = "2025-06-30"
+
+[d1_databases]
+DB = { binding = "DB", database_name = "lunch_orders", database_id = "<D1_DATABASE_ID>" }
+
+[assets]
+directory = "./dist"
+binding = "ASSETS"


### PR DESCRIPTION
## Summary
- add Cloudflare worker code and schema for lunch order app
- implement Svelte frontend with user and admin interfaces
- configure Tailwind, PostCSS and Vite
- add deployment instructions in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68656ae9cb008333a25bd524c321ee52